### PR TITLE
Upgrade bs-platform to ^5.0.4

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -2,3 +2,13 @@ PKG result bytes
 S src
 S test
 B _build/**
+
+####{BSB GENERATED: NO EDIT
+FLG -ppx /Users/jwhitley/src/3p/bs-cmdliner/node_modules/bs-platform/lib/bsppx.exe
+S /Users/jwhitley/src/3p/bs-cmdliner/node_modules/bs-platform/lib/ocaml
+B /Users/jwhitley/src/3p/bs-cmdliner/node_modules/bs-platform/lib/ocaml
+FLG -nostdlib -color always
+FLG -w -30-40+6+7+27+32..39+44+45+101-32-35-27-44-6
+S src
+B lib/bs/src
+####BSB GENERATED: NO EDIT}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "bs-platform": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-4.0.1.tgz",
-      "integrity": "sha1-VEtYwqUymc9Aa1dHfgY4nkratCE="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-5.0.4.tgz",
+      "integrity": "sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "homepage": "https://github.com/dbuenzli/cmdliner#readme",
   "dependencies": {
-    "bs-platform": "^4.0.1"
+    "bs-platform": "^5.0.4"
   }
 }


### PR DESCRIPTION
This is a quick go at upgrading bs-platform to current v5.  Apologies if I've left something obvious out; I'm new to the BuckleScript toolchain.